### PR TITLE
Update to use analysis ids instead of experiment ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cov_viz"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "cov_viz_ds",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cov_viz"
 description = "Generate data used by the CCGR Portal experiment coverage visualizer"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 publish = false
 

--- a/src/build_data.rs
+++ b/src/build_data.rs
@@ -190,7 +190,7 @@ pub fn build_data(options: &Options, client: &mut Client) -> Result<CoverageData
     let facet_range_statement = client.prepare(r#"
         SELECT MIN(((search_regulatoryeffectobservation.facet_num_values -> $1))::double precision) AS min, MAX(((search_regulatoryeffectobservation.facet_num_values -> $1))::double precision) AS max
         FROM search_regulatoryeffectobservation
-        WHERE search_regulatoryeffectobservation.experiment_accession_id = $2"#
+        WHERE search_regulatoryeffectobservation.analysis_accession_id = $2"#
     )?;
     let dir_facet = all_facets
         .iter()
@@ -225,20 +225,20 @@ pub fn build_data(options: &Options, client: &mut Client) -> Result<CoverageData
     let reg_effects_statement = client.prepare(r#"
         SELECT search_regulatoryeffectobservation.id, search_regulatoryeffectobservation.facet_num_values
         FROM search_regulatoryeffectobservation
-        WHERE search_regulatoryeffectobservation.experiment_accession_id = $1"#
+        WHERE search_regulatoryeffectobservation.analysis_accession_id = $1"#
     )?;
     let reg_effects_chromo_statement = client.prepare(r#"
         SELECT search_regulatoryeffectobservation.id, search_regulatoryeffectobservation.facet_num_values
         FROM search_regulatoryeffectobservation
         INNER JOIN search_regulatoryeffectobservation_sources as re_ta ON (search_regulatoryeffectobservation.id = re_ta.regulatoryeffectobservation_id)
         INNER JOIN search_dnafeature as fa ON (fa.id = re_ta.dnafeature_id)
-        WHERE search_regulatoryeffectobservation.experiment_accession_id = $1 and fa.chrom_name = $2"#
+        WHERE search_regulatoryeffectobservation.analysis_accession_id = $1 and fa.chrom_name = $2"#
     )?;
     let reg_effects = match &options.chromo {
-        None => client.query(&reg_effects_statement, &[&options.experiment_accession_id])?,
+        None => client.query(&reg_effects_statement, &[&options.analysis_accession_id])?,
         Some(chromo) => client.query(
             &reg_effects_chromo_statement,
-            &[&options.experiment_accession_id, &chromo],
+            &[&options.analysis_accession_id, &chromo],
         )?,
     };
     let mut reg_effect_num_facets: FxHashMap<DbID, FxHashMap<&str, f32>> = FxHashMap::default();
@@ -526,7 +526,7 @@ pub fn build_data(options: &Options, client: &mut Client) -> Result<CoverageData
         } else if facet.name == FACET_EFFECT_SIZE {
             let facet_range_row = client.query_one(
                 &facet_range_statement,
-                &[&FACET_EFFECT_SIZE, &options.experiment_accession_id],
+                &[&FACET_EFFECT_SIZE, &options.analysis_accession_id],
             )?;
             facet.range = Some(FacetRange(
                 facet_range_row.get::<&str, f64>("min") as f32,
@@ -535,7 +535,7 @@ pub fn build_data(options: &Options, client: &mut Client) -> Result<CoverageData
         } else if facet.name == FACET_SIGNIFICANCE {
             let facet_range_row = client.query_one(
                 &facet_range_statement,
-                &[&FACET_SIGNIFICANCE, &options.experiment_accession_id],
+                &[&FACET_SIGNIFICANCE, &options.analysis_accession_id],
             )?;
             facet.range = Some(FacetRange(
                 facet_range_row.get::<&str, f64>("min") as f32,

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,7 @@ const DATABASE_URL_KEY: &str = "DATABASE_URL";
 #[derive(Debug)]
 pub struct Options {
     pub output_location: PathBuf,
-    pub experiment_accession_id: String,
+    pub analysis_accession_id: String,
     pub assembly_name: String,
     pub connection_string: String,
     pub bucket_size: u32,
@@ -33,7 +33,7 @@ impl Options {
 
         Options {
             output_location: path,
-            experiment_accession_id: args[2].clone(),
+            analysis_accession_id: args[2].clone(),
             assembly_name: args[3].clone(),
             bucket_size: match args.get(4) {
                 Some(size) => u32::from_str_radix(size, 10).unwrap(),


### PR DESCRIPTION
Each experiment may have multiple analyses. Each analysis should have a separate coverage map. This modifies cov_viz to build the coverage data based on the analysis accession id instead of the experiment accession id.